### PR TITLE
Include additional commands for autocomplete

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AssignCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignCommand.java
@@ -29,6 +29,7 @@ public class AssignCommand extends UndoableCommand {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Assigns a player or a group of players to a team "
             + "by the index number used in the last player listing.\n"
+            + "You can also unassign a player by leaving out TEAM_NAME as an input.\n"
             + "Team of the player will be updated and will be added to team.\n"
             + "Only 1 team can be assigned to each player.\n"
             + "Parameters: "
@@ -36,10 +37,10 @@ public class AssignCommand extends UndoableCommand {
             + PREFIX_INDEX + "INDEX (must be a positive integer) "
             + "[INDEX]...\n"
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_TEAM_NAME + "Arsenal "
+            + "Arsenal "
             + PREFIX_INDEX + "1 2";
 
-    public static final String MESSAGE_PARAMETERS = PREFIX_TEAM_NAME + "TEAM_NAME "
+    public static final String MESSAGE_PARAMETERS = "[TEAM_NAME] "
             + PREFIX_INDEX + "INDEX "
             + "[INDEX]...";
 

--- a/src/main/java/seedu/address/logic/commands/ChangeThemeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ChangeThemeCommand.java
@@ -20,6 +20,8 @@ public class ChangeThemeCommand extends Command {
             + "Parameters: THEME (must be either Light, or Dark)\n"
             + "Examples: changeTheme Light, cte Dark";
 
+    public static final String MESSAGE_PARAMETERS = "THEME (Light or Dark)";
+
     public static final String MESSAGE_THEME_SUCCESS = "Theme updated to: %1$s";
 
     private final String theme;

--- a/src/main/java/seedu/address/logic/commands/CommandTrie.java
+++ b/src/main/java/seedu/address/logic/commands/CommandTrie.java
@@ -26,7 +26,9 @@ public class CommandTrie {
                 HelpCommand.COMMAND_WORD, SelectCommand.COMMAND_WORD, HistoryCommand.COMMAND_WORD,
                 ListCommand.COMMAND_WORD, RedoCommand.COMMAND_WORD,  UndoCommand.COMMAND_WORD,
                 SortCommand.COMMAND_WORD, SetCommand.COMMAND_WORD, RemarkCommand.COMMAND_WORD,
-                CreateCommand.COMMAND_WORD
+                CreateCommand.COMMAND_WORD, RemoveCommand.COMMAND_WORD, AssignCommand.COMMAND_WORD,
+                RenameCommand.COMMAND_WORD, ViewCommand.COMMAND_WORD, ChangeThemeCommand.COMMAND_WORD,
+                KeyCommand.COMMAND_WORD, TogglePrivacyCommand.COMMAND_WORD
         ).collect(Collectors.toSet());
 
         for (String command : commandSet) {
@@ -43,7 +45,13 @@ public class CommandTrie {
         commandMap.put(SetCommand.COMMAND_WORD, SetCommand.MESSAGE_PARAMETERS);
         commandMap.put(RemarkCommand.COMMAND_WORD, RemarkCommand.MESSAGE_PARAMETERS);
         commandMap.put(CreateCommand.COMMAND_WORD, CreateCommand.MESSAGE_PARAMETERS);
-
+        commandMap.put(RemoveCommand.COMMAND_WORD, RemoveCommand.MESSAGE_PARAMETERS);
+        commandMap.put(AssignCommand.COMMAND_WORD, AssignCommand.MESSAGE_PARAMETERS);
+        commandMap.put(RenameCommand.COMMAND_WORD, RenameCommand.MESSAGE_PARAMETERS);
+        commandMap.put(ViewCommand.COMMAND_WORD, ViewCommand.MESSAGE_PARAMETERS);
+        commandMap.put(ChangeThemeCommand.COMMAND_WORD, ChangeThemeCommand.MESSAGE_PARAMETERS);
+        commandMap.put(KeyCommand.COMMAND_WORD, KeyCommand.MESSAGE_PARAMETERS);
+        commandMap.put(TogglePrivacyCommand.COMMAND_WORD, TogglePrivacyCommand.MESSAGE_PARAMETERS);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/CreateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CreateCommand.java
@@ -16,7 +16,7 @@ public class CreateCommand extends UndoableCommand {
     public static final String COMMAND_WORD = "create";
     public static final String COMMAND_ALIAS = "ct";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + "Creates a team in MTM. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Creates a team in MTM. "
             + "Parameters: "
             + "TEAM_NAME\n"
             + "Example: " + COMMAND_WORD + " "

--- a/src/main/java/seedu/address/logic/commands/KeyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/KeyCommand.java
@@ -24,6 +24,8 @@ public class KeyCommand extends Command {
             + "Example: " + COMMAND_WORD
             + " myPassword";
 
+    public static final String MESSAGE_PARAMETERS = "[PASSWORD]";
+
     public static final String MESSAGE_SUCCESS = "MTM lock toggled!";
     public static final String MESSAGE_WRONG_PASS = "Password entered is incorrect. Please try again.";
 

--- a/src/main/java/seedu/address/logic/commands/RenameCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RenameCommand.java
@@ -31,7 +31,7 @@ public class RenameCommand extends UndoableCommand {
             + " Arsenal "
             + PREFIX_TEAM_NAME + "Neo Arsenal";
 
-    public static final String MESSAGE_PARAMETERS = "TEAM_NAME"
+    public static final String MESSAGE_PARAMETERS = "TEAM_NAME "
             + PREFIX_TEAM_NAME + "RENAME_TEAM_NAME";
 
     public static final String MESSAGE_RENAME_SUCCESS = "\"%1$s\" is renamed to \"%2$s\".";

--- a/src/main/java/seedu/address/logic/commands/TogglePrivacyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TogglePrivacyCommand.java
@@ -43,15 +43,22 @@ public class TogglePrivacyCommand extends UndoableCommand {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Toggles the field privacy of the person"
             + " identified by the index number used in the last person listing.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + "[" + PREFIX_PHONE + "]"
-            + "[" + PREFIX_EMAIL + "]"
-            + "[" + PREFIX_REMARK + "]"
-            + "[" + PREFIX_RATING + "]"
+            + "[" + PREFIX_PHONE + "] "
+            + "[" + PREFIX_EMAIL + "] "
+            + "[" + PREFIX_REMARK + "] "
+            + "[" + PREFIX_RATING + "] "
             + "[" + PREFIX_ADDRESS + "]\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + " "
             + PREFIX_EMAIL + " "
             + PREFIX_ADDRESS;
+
+    public static final String MESSAGE_PARAMETERS = "INDEX "
+            + "[" + PREFIX_PHONE + "] "
+            + "[" + PREFIX_EMAIL + "] "
+            + "[" + PREFIX_REMARK + "] "
+            + "[" + PREFIX_RATING + "] "
+            + "[" + PREFIX_ADDRESS + "]";
 
     public static final String MESSAGE_SUCCESS = "Changed the Privacy of the Person: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";


### PR DESCRIPTION
@lithiumlkid There's a bug with the `setTagColour` and `changeTheme` commands.

Pressed `tab` but it turns red.
![image](https://user-images.githubusercontent.com/3660764/38607015-36f05bb0-3daa-11e8-96e2-ea3f592c7edf.png)

Same for the `changeTheme` command.
![image](https://user-images.githubusercontent.com/3660764/38607038-4251492e-3daa-11e8-9e16-99d196ef9089.png)

It does not remove the parameters when i press tab again.